### PR TITLE
hoping to solve --force-reinstall errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,11 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["ipython", "ipyfilechooser"],
+    install_requires=[
+        "ipython==8.3.0",
+        "ipyfilechooser",
+        "jupyterlab-widgets==1.1.0"
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Fixes #56 

## Proposed Changes

  - Solves the "Error displaying widget: model not found" bug (#56) by pegging the ipython and jupyterlab-widgets dependencies to a specific version.

**Note:** This is a temporary solution, further work needs to be done down the road to increase the range of dependencies and eventually get this all working with the latest version of widgets.