### PR TITLE
v0.2.3 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, CyberGIS Center'
 author = 'CyberGIS Center'
 
 # The full version, including alpha/beta/rc tags
-release = 'v2'
+release = 'v0.2.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,8 +1,24 @@
 Release Notes
 =============
 
-[v0.2.2] - Ongoing
-------------------
+[v0.2.3] - 2022-10-06
+---------------------
+
+Added
+^^^^^
+
+* "Past Results" Tab with download buttons `#37 <https://github.com/cybergis/cybergis-compute-python-sdk/pull/37>`_
+* ``list_jupyter_host()`` functionality to see the Core whitelist `#55 <https://github.com/cybergis/cybergis-compute-python-sdk/pull/55>`_
+
+Updated
+^^^^^^^
+
+* Fix for broken ``list_job()`` function `#51 <https://github.com/cybergis/cybergis-compute-python-sdk/pull/51>`_ 
+* Fix for "error displaying widget: model not found" when using --force-install without --no-deps `#57 <https://github.com/cybergis/cybergis-compute-python-sdk/pull/57>`_ 
+* Minor UI bug fixes and QOL changes `#54 <https://github.com/cybergis/cybergis-compute-python-sdk/pull/54>`_
+
+[v0.2.2] - 2022-09-08
+---------------------
 
 Added
 ^^^^^

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.2.2',
+    version='0.2.3',
 
     description='CyberGISX compatable HPC job submission client',
     long_description=long_description,


### PR DESCRIPTION
Updates the docs, setup.py, and configs for the v0.2.3 release which is available now on PyPi: https://pypi.org/project/cybergis-compute-client/0.2.3/