### PR TITLE
Allow users to name folders in the UI

### DIFF
--- a/cybergis_compute_client/UI.py
+++ b/cybergis_compute_client/UI.py
@@ -236,7 +236,7 @@ class UI:
             [self.email['checkbox'], self.email['text']])
         with self.email['output']:
             display(self.email['hbox'])
-    
+
     def renderNaming(self):
         """
         Displays a box to toggle naming the job being submitted
@@ -253,6 +253,7 @@ class UI:
         self.name['hbox'] = widgets.HBox(
             [self.name['checkbox'], self.name['text']])
         with self.name['output']:
+            display(Markdown("Please note that the naming feature only allows for names made up of letters, numbers, and the characters '  ', ' . ', and ' _ '. Other characters will be removed from your input."))
             display(self.name['hbox'])
 
     def renderSlurm(self):
@@ -542,14 +543,14 @@ class UI:
             self.folders['output'] = widgets.Output()
         with self.folders['output']:
             display(Markdown("We will do our best to keep this data for 90 days, but cannot guarantee it won’t be deleted sooner."))
+            display(Markdown("Please note that the renaming feature only allows for names made up of letters, numbers, and the characters '  ', ' . ', and ' _ '. Other characters will be removed from your input."))
             pageNum = self.folderPage
             numFolders = self.foldersPerPage
             firstFolder = pageNum * numFolders
             lastFolder = firstFolder + numFolders
             if (lastFolder >= len(folders["folder"])):
                 lastFolder = len(folders["folder"])
-            display(Markdown('<br> **Showing folders ' + str(firstFolder + 1) + ' to ' + str(lastFolder) + ' of ' + str(len(folders["folder"]))
-                             + ' for ' + self.compute.username.split('@', 1)[0] + '**'))
+            display(Markdown('<br> **Showing folders ' + str(firstFolder + 1) + ' to ' + str(lastFolder) + ' of ' + str(len(folders["folder"])) + ' for ' + self.compute.username.split('@', 1)[0] + '**'))
             backButton = widgets.Button(description="Previous Page")
             nextButton = widgets.Button(description="Next Page")
             pageButtons = widgets.HBox([backButton, nextButton])
@@ -558,11 +559,9 @@ class UI:
             display(pageButtons)
             listNames = []
             for i in folders["folder"]:
-                if i['name'] != None:
+                if i['name'] is not None:
                     listNames.append(i['name'])
             listNames = [*set(listNames)]
-            # for k in range(firstFolder, lastFolder + 1):
-            #     i = reversed(folders["folder"]).at(k)
             for i in list(reversed(folders["folder"]))[firstFolder:lastFolder]:
                 headers = ['id', 'name', 'hpc', 'userId', 'isWritable', 'createdAt', 'updatedAt', 'deletedAt']
                 data = [[]]
@@ -581,7 +580,7 @@ class UI:
                 display(renameWidgets)
             display(Markdown('<br> **Showing folders ' + str(firstFolder + 1) + ' to ' + str(lastFolder) + ' of ' + str(len(folders["folder"])) + '**'))
             display(pageButtons)
-            
+
     def renderRecentlySubmittedJobs(self):
         """
         Display the jobs most recently submitted by the logged in user, allows user to restore these jobs.
@@ -732,14 +731,14 @@ class UI:
             self.renderRecentlySubmittedJobs()
             self.renderSubmitNew()
             """ If the user has indicated the job should be named and provided a name, the produced files are named here """
-            if data['name'] != None and data['name'] != "":
+            if data['name'] is not None and data['name'] != "":
                 nameForFile = self.makeNameSafe(data['name'])
                 jobs = self.compute.client.request('GET', '/user/job', {'jupyterhubApiToken': self.compute.jupyterhubApiToken})
                 job = jobs['job'][len(jobs['job']) - 1]
                 useFolder = job['remoteExecutableFolder']['id']
-                response = self.compute.client.request('PUT', '/folder/' + useFolder, {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name':nameForFile + '_executable'})
+                self.compute.client.request('PUT', '/folder/' + useFolder, {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name': nameForFile + '_executable'})
                 useFolder = job['remoteResultFolder']['id']
-                response = self.compute.client.request('PUT', '/folder/' + useFolder, {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name':nameForFile + '_result'})
+                self.compute.client.request('PUT', '/folder/' + useFolder, {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name': nameForFile + '_result'})
         return on_click
 
     def onJobDropdownChange(self):
@@ -826,15 +825,15 @@ class UI:
                 "toEndpoint": localEndpoint
             })
         return on_click
-    
+
     def onRenameJobButton(self, folder, wdgt):
         def on_click(change):
             newName = self.makeNameSafe(wdgt.value)
-            response = self.compute.client.request('PUT', '/folder/' + folder["id"], {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name' : newName})
+            self.compute.client.request('PUT', '/folder/' + folder["id"], {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name': newName})
             self.folders['output'].clear_output()
             self.renderFolders()
         return on_click
-    
+
     def onPrevPageButton(self):
         def on_click(change):
             if (self.folderPage - 1 >= 0):
@@ -842,7 +841,7 @@ class UI:
             self.folders['output'].clear_output()
             self.renderFolders()
         return on_click
-    
+
     def onNextPageButton(self, totalJobs):
         def on_click(change):
             if ((self.folderPage + 1) * self.foldersPerPage < totalJobs):
@@ -850,7 +849,7 @@ class UI:
             self.folders['output'].clear_output()
             self.renderFolders()
         return on_click
-    
+
     # helpers
     def init(self):
         """
@@ -912,9 +911,9 @@ class UI:
 
     """ Used to ensure that folders have names with only safe characters """
     def makeNameSafe(self, text):
-        keepcharacters = (' ','.','_')
+        keepcharacters = (' ', '.', '_')
         return "".join(c for c in text if c.isalnum() or c in keepcharacters).rstrip()
-            
+
     # data
     def get_data(self):
         """

--- a/cybergis_compute_client/UI.py
+++ b/cybergis_compute_client/UI.py
@@ -253,7 +253,7 @@ class UI:
         self.name['hbox'] = widgets.HBox(
             [self.name['checkbox'], self.name['text']])
         with self.name['output']:
-            display(Markdown("Please note that the naming feature only allows for names made up of letters, numbers, and the characters '  ', ' . ', and ' _ '. Other characters will be removed from your input."))
+            display(Markdown("Please note that the naming feature only allows for names made up of letters, numbers, and the characters ' . ' and ' _ '. Other characters will be removed from your input."))
             display(self.name['hbox'])
 
     def renderSlurm(self):
@@ -543,7 +543,7 @@ class UI:
             self.folders['output'] = widgets.Output()
         with self.folders['output']:
             display(Markdown("We will do our best to keep this data for 90 days, but cannot guarantee it won’t be deleted sooner."))
-            display(Markdown("Please note that the renaming feature only allows for names made up of letters, numbers, and the characters '  ', ' . ', and ' _ '. Other characters will be removed from your input."))
+            display(Markdown("Please note that the renaming feature only allows for names made up of letters, numbers, and the characters ' . ' and ' _ '. Other characters will be removed from your input."))
             pageNum = self.folderPage
             numFolders = self.foldersPerPage
             firstFolder = pageNum * numFolders
@@ -911,7 +911,7 @@ class UI:
 
     """ Used to ensure that folders have names with only safe characters """
     def makeNameSafe(self, text):
-        keepcharacters = (' ', '.', '_')
+        keepcharacters = ('.', '_')
         return "".join(c for c in text if c.isalnum() or c in keepcharacters).rstrip()
 
     # data

--- a/cybergis_compute_client/UI.py
+++ b/cybergis_compute_client/UI.py
@@ -724,9 +724,9 @@ class UI:
                 jobs = self.compute.client.request('GET', '/user/job', {'jupyterhubApiToken': self.compute.jupyterhubApiToken})
                 job = jobs['job'][len(jobs['job']) - 1]
                 useFolder = job['remoteExecutableFolder']['id']
-                response = self.put('/folder/' + useFolder, body={'name':nameForFile + '_executable'})
+                response = self.compute.client.request('PUT', '/folder/' + useFolder, {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name':nameForFile + '_executable'})
                 useFolder = job['remoteResultFolder']['id']
-                response = self.put('/folder/' + useFolder, body={'name':nameForFile + '_result'})
+                response = self.compute.client.request('PUT', '/folder/' + useFolder, {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name':nameForFile + '_result'})
         return on_click
 
     def onJobDropdownChange(self):
@@ -818,26 +818,11 @@ class UI:
         def on_click(change):
             keepcharacters = (' ','.','_')
             newName = "".join(c for c in wdgt.value if c.isalnum() or c in keepcharacters).rstrip()
-            response = self.put('/folder/' + folder["id"], body={'name':newName})
+            response = self.compute.client.request('PUT', '/folder/' + folder["id"], {'jupyterhubApiToken': self.compute.jupyterhubApiToken, 'name' : newName})
             self.folders['output'].clear_output()
             self.renderFolders()
         return on_click
     
-    def put(self, route, body=None, auth=True):
-        """Sends a put request to the api with auth token"""
-        if body is None:
-            body = {}
-        """This line changes if not used for cgjobsup - needs update"""
-        uri = "https://cgjobsup.cigi.illinois.edu/v2" + route
-        headers = {'Content-type': 'application/json'}
-        if auth:
-            body["jupyterhubApiToken"] = self.compute.jupyterhubApiToken
-        return requests.put(
-            uri,
-            headers=headers,
-            data=json.dumps(body)
-        )
-
     # helpers
     def init(self):
         """


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - [x] Adds UI elements to job submission and past results  pages to allow the user to set folder names
  - [x] Folder names are reflected and updated in the UI (past jobs page and your jobs pages)
  - [x] When folders are downloaded they include the user assigned name (as well as the previously included jobID information)
  - [x] Folders are displayed in reverse order so more recent jobs are at the top
  - [x] Add naming rules to [this](https://github.com/cybergis/cybergis-compute-python-sdk/blob/85a36626b24be85444e2073d80978ace3f1fd5be/cybergis_compute_client/UI.py#L544) location