### PR TITLE
Display username 2023 07 31

### DIFF
--- a/cybergis_compute_client/UI.py
+++ b/cybergis_compute_client/UI.py
@@ -84,6 +84,7 @@ class UI:
             display(Markdown('# Welcome to CyberGIS-Compute'))
             display(Markdown('A scalable middleware framework for enabling high-performance and data-intensive geospatial research and education on CyberGIS-Jupyter'))
             display(divider)
+            display(Markdown('**Your CyberGIS-Compute Username:** ' + str(self.compute.username)))
             self.renderAnnouncements()
             display(self.jobTemplate['output'])
             display(self.description['output'])

--- a/cybergis_compute_client/UI.py
+++ b/cybergis_compute_client/UI.py
@@ -82,7 +82,7 @@ class UI:
         job_config = widgets.Output()
         with job_config:
             display(Markdown('# Welcome to CyberGIS-Compute'))
-            display(Markdown('A scalable middleware framework for enabling high-performance and data-intensive geospatial research and education on CyberGIS-Jupyter'))
+            display(Markdown('A scalable middleware framework for enabling high-performance and data-intensive geospatial research and education on CyberGIS-Jupyter. [Click here for documentation.](https://cybergis.github.io/cybergis-compute-python-sdk/index.html)'))
             display(divider)
             display(Markdown('**Your CyberGIS-Compute Username:** ' + str(self.compute.username)))
             self.renderAnnouncements()


### PR DESCRIPTION
Fixes #69 

## Proposed Changes

  - Adds a "Your CyberGIS-Compute Username: ..." line to the UI directly below the divider describing CyberGIS-Compute.
  - Adds a link to the documentation to the description of CyberGIS-Compute.

![image](https://github.com/cybergis/cybergis-compute-python-sdk/assets/36479843/a6ac2b07-159f-4bff-b0eb-e8b96362eb6f)
