### PR TITLE
Revert "add specification for allocation and partition"

### DIFF
--- a/cybergis_compute_client/UI.py
+++ b/cybergis_compute_client/UI.py
@@ -334,11 +334,9 @@ class UI:
             if self.slurm[i] is not None:
                 w.append(self.slurm[i])
         self.slurm['vbox'] = widgets.VBox(w)
-        self.slurm['allocation'] = widgets.HBox([widgets.Label("Allocation: "), widgets.Text(placeholder='(Optional) Specify Allocation', style=self.style)])
-        self.slurm['partition'] = widgets.HBox([widgets.Label("Partition: "), widgets.Text(placeholder='(Optional) Specify Partition', style=self.style)])
 
         # settings end
-        self.slurm['accordion'] = widgets.Accordion(children=(widgets.VBox(children=(self.slurm['description'], self.slurm['vbox'], widgets.Label("In most cases, specifying an allocation and partition is unnecessary. Do not input anything unless you have a non-default allocation and/or partition to specify."), self.slurm['allocation'], self.slurm['partition'])),), selected_index=None)
+        self.slurm['accordion'] = widgets.Accordion(children=(widgets.VBox(children=(self.slurm['description'], self.slurm['vbox'])),), selected_index=None)
         self.slurm['accordion'].set_title(0, 'Slurm Computing Configurations')
         with self.slurm['output']:
             display(self.slurm['accordion'])
@@ -1039,21 +1037,13 @@ class UI:
             dict : Information about the job submitted (template,
             computing resource used, slurm rules, param rules, user email)
         """
-        allocation = None
-        if self.slurm['allocation'].value != '':
-            allocation = self.slurm['allocation'].value
-        partition = None
-        if self.slurm['partition'].value != '':
-            partition = self.slurm['partition'].value
         out = {
             'job_template': self.jobTemplate['dropdown'].value,
             'computing_resource': self.computingResource['dropdown'].value,
             'slurm': {
                 'time': '01:00:00',
                 'num_of_task': 1,
-                'cpu_per_task': 1,
-                'allocation': allocation,
-                'partition': partition
+                'cpu_per_task': 1
             },
             'param': {},
             'email': self.email['text'].value if self.email[


### PR DESCRIPTION
Reverts cybergis/cybergis-compute-python-sdk#88

Found a bug:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/.local/python3-0.9.0/lib/python3.8/site-packages/cybergis_compute_client/UI.py:791, in UI.onSubmitButtonClick.<locals>.on_click(change)
    789 self.compute.login()
    790 localDataFolder = None
--> 791 data = self.get_data()
    792 if data['computing_resource'] != 'local_hpc':
    793     self.jupyter_globus = self.compute.get_user_jupyter_globus()

File ~/.local/python3-0.9.0/lib/python3.8/site-packages/cybergis_compute_client/UI.py:1043, in UI.get_data(self)
   1034 """
   1035 Get data about the job submitted (template, computing resource used,
   1036 slurm rules, param rules, user email)
   (...)
   1040     computing resource used, slurm rules, param rules, user email)
   1041 """
   1042 allocation = None
-> 1043 if self.slurm['allocation'].value != '':
   1044     allocation = self.slurm['allocation'].value
   1045 partition = None

AttributeError: 'HBox' object has no attribute 'value'
```